### PR TITLE
test cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "rdf-linkchecker"
-version = "1.0.0"
+version = "1.1.0"
 description = "Awesome `rdf-linkchecker` is a Python cli/package created with https://github.com/TezRomacH/python-package-template"
 readme = "README.md"
 authors = ["WWU-AMM <rene.fritze@wwu.de>"]

--- a/rdf_linkchecker/__main__.py
+++ b/rdf_linkchecker/__main__.py
@@ -68,7 +68,7 @@ def main(
     """Check URLs in given RDF files"""
     checker = Checker(config_file)
     checker.add_urls(get_urls(files))
-    sys.exit(checker.check())
+    sys.exit(int(checker.check()) - 1)
 
 
 if __name__ == "__main__":

--- a/rdf_linkchecker/checkers/linkchecker_based.py
+++ b/rdf_linkchecker/checkers/linkchecker_based.py
@@ -1,4 +1,4 @@
-"""Ccheker implemented with https://github.com/linkchecker/linkchecker
+"""Checker implemented with https://github.com/linkchecker/linkchecker
 
 Too complex to make it do what simple tasks we need.
 """
@@ -7,15 +7,12 @@ from typing import List, Optional
 
 from pathlib import Path
 
-from linkcheck import LOG_CMDLINE, configuration, log, logconf
-from linkcheck.cmdline import aggregate_url
-from linkcheck.command import linkchecker
-from linkcheck.command.setup_config import setup_config
-from linkcheck.director import check_urls, console, get_aggregate
-
 
 class Checker:
     def __init__(self, configfile: Optional[Path] = None):
+        from linkcheck import configuration, logconf
+        from linkcheck.director import console, get_aggregate
+
         self.config = configuration.Configuration()
         if configfile:
             self.config.read(files=[configfile])
@@ -29,10 +26,14 @@ class Checker:
         self.aggregate = get_aggregate(self.config)
 
     def add_urls(self, urls: List[str]):
+        from linkcheck.cmdline import aggregate_url
+
         for url in urls:
             aggregate_url(aggregate=self.aggregate, url=url)
 
     def check(self):
+        from linkcheck.director import check_urls
+
         check_urls(self.aggregate)
 
         stats = self.config["logger"].stats

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,4 @@ import pytest
 
 @pytest.fixture()
 def ttl_files(shared_datadir):
-    return shared_datadir.glob("*.ttl")
+    return list(shared_datadir.glob("*.ttl"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+from typer.testing import CliRunner
+
+from rdf_linkchecker.__main__ import app
+
+
+def test_fail(ttl_files):
+    runner = CliRunner()
+    result = runner.invoke(app, ttl_files)
+    assert result.exit_code != 0
+
+
+def test_success(ttl_files, shared_datadir):
+    runner = CliRunner()
+    cfn = str(shared_datadir / "skip_missing.config")
+    # cannot mix Path objects and strings in arg list
+    args = ["--config-file", f"{cfn}"] + [str(t) for t in ttl_files]
+    result = runner.invoke(app, args)
+    assert result.exit_code == 0


### PR DESCRIPTION
- add tests for Typer cli
- make unused linkchecker importable

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/renefritze/rdf-linkchecker/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/renefritze/rdf-linkchecker/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
